### PR TITLE
Center content for mobile responsiveness

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -49,9 +49,6 @@
   .app {
     padding: 0.5rem;
     min-height: 100svh; /* Small viewport height for mobile */
-    /* Ensure content is properly centered in visible area */
-    justify-content: center;
-    align-items: center;
   }
   
   .app h1 {
@@ -76,9 +73,6 @@
   .app {
     padding: 0.25rem;
     min-height: 100svh; /* Small viewport height for mobile */
-    /* Ensure content is properly centered in visible area */
-    justify-content: center;
-    align-items: center;
   }
   
   .app h1 {

--- a/src/App.css
+++ b/src/App.css
@@ -4,6 +4,7 @@
   justify-content: center;
   align-items: center;
   min-height: 100vh;
+  min-height: 100dvh; /* Dynamic viewport height for mobile */
   width: 100%;
   padding: 1rem;
   box-sizing: border-box;
@@ -47,6 +48,10 @@
 @media (max-width: 768px) {
   .app {
     padding: 0.5rem;
+    min-height: 100svh; /* Small viewport height for mobile */
+    /* Ensure content is properly centered in visible area */
+    justify-content: center;
+    align-items: center;
   }
   
   .app h1 {
@@ -70,6 +75,10 @@
 @media (max-width: 480px) {
   .app {
     padding: 0.25rem;
+    min-height: 100svh; /* Small viewport height for mobile */
+    /* Ensure content is properly centered in visible area */
+    justify-content: center;
+    align-items: center;
   }
   
   .app h1 {

--- a/src/index.css
+++ b/src/index.css
@@ -76,9 +76,6 @@ button:focus-visible {
   
   #root {
     min-height: 100svh; /* Small viewport height */
-    /* Ensure content starts at the top of the visible area */
-    justify-content: center;
-    align-items: center;
   }
   
   h1 {

--- a/src/index.css
+++ b/src/index.css
@@ -27,6 +27,7 @@ body {
   padding: 0;
   min-width: 320px;
   min-height: 100vh;
+  min-height: 100dvh; /* Dynamic viewport height for mobile */
   width: 100%;
   overflow-x: hidden;
   /* Remove display: flex and place-items: center to avoid conflicts */
@@ -35,6 +36,7 @@ body {
 #root {
   width: 100%;
   min-height: 100vh;
+  min-height: 100dvh; /* Dynamic viewport height for mobile */
   display: flex;
   justify-content: center;
   align-items: center;
@@ -68,6 +70,15 @@ button:focus-visible {
 @media (max-width: 768px) {
   body {
     font-size: 14px;
+    /* Ensure mobile browsers use the visible viewport */
+    min-height: 100svh; /* Small viewport height */
+  }
+  
+  #root {
+    min-height: 100svh; /* Small viewport height */
+    /* Ensure content starts at the top of the visible area */
+    justify-content: center;
+    align-items: center;
   }
   
   h1 {
@@ -83,6 +94,11 @@ button:focus-visible {
 @media (max-width: 480px) {
   body {
     font-size: 13px;
+    min-height: 100svh; /* Small viewport height */
+  }
+  
+  #root {
+    min-height: 100svh; /* Small viewport height */
   }
   
   h1 {


### PR DESCRIPTION
Fix mobile viewport centering by using dynamic viewport units (`dvh`, `svh`).

On mobile, `100vh` doesn't account for dynamic browser chrome (address bar, etc.), causing content to appear below the fold and requiring initial scrolling. This PR uses `100dvh` and `100svh` to ensure the page correctly centers within the visible viewport area on load.