### PR TITLE
Create fixed initials icon with scroll functionality

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import './styles/App.css'
 import Title from './components/Title/Title'
 import TypeWriter from './components/TypeWriter/TypeWriter'
 import ExperienceList from './components/ExperienceList/ExperienceList'
+import InitialsIcon from './components/InitialsIcon/InitialsIcon'
 import reactLogo from './assets/react.svg'
 import viteLogo from './assets/vite.svg'
 import mashginLogo from './assets/mashgin-logo.png'
@@ -89,6 +90,7 @@ function App() {
 
   return (
     <div className="app">
+      <InitialsIcon visible={titleVisible} />
       <Title title="Brandon Choi" />
       
       <h1 className={`main-title ${titleVisible ? 'fade-in' : ''}`}>Brandon Choi</h1>

--- a/src/components/InitialsIcon/InitialsIcon.css
+++ b/src/components/InitialsIcon/InitialsIcon.css
@@ -1,0 +1,57 @@
+.initials-icon {
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background-color: var(--color-text-primary); /* White background */
+  color: var(--color-bg-primary); /* Black text */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  font-weight: 700;
+  font-family: 'Futura', serif;
+  cursor: pointer;
+  z-index: 1000;
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: opacity 1.5s ease-out, transform 1.5s ease-out, box-shadow 0.3s ease, transform 0.3s ease;
+  user-select: none;
+}
+
+.initials-icon.fade-in {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.initials-icon:hover {
+  box-shadow: 0 4px 12px var(--color-shadow-glow);
+  transform: translateY(-2px) scale(1.05);
+}
+
+.initials-icon:active {
+  transform: translateY(0) scale(0.95);
+}
+
+/* Responsive design for mobile devices */
+@media (max-width: 768px) {
+  .initials-icon {
+    width: 45px;
+    height: 45px;
+    font-size: 1.1rem;
+    top: 15px;
+    left: 15px;
+  }
+}
+
+@media (max-width: 480px) {
+  .initials-icon {
+    width: 40px;
+    height: 40px;
+    font-size: 1rem;
+    top: 10px;
+    left: 10px;
+  }
+}

--- a/src/components/InitialsIcon/InitialsIcon.jsx
+++ b/src/components/InitialsIcon/InitialsIcon.jsx
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react'
+import './InitialsIcon.css'
+
+const InitialsIcon = ({ visible = false }) => {
+  const handleClick = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    })
+  }
+
+  return (
+    <div 
+      className={`initials-icon ${visible ? 'fade-in' : ''}`}
+      onClick={handleClick}
+    >
+      BC
+    </div>
+  )
+}
+
+export default InitialsIcon

--- a/src/components/InitialsIcon/InitialsIcon.jsx
+++ b/src/components/InitialsIcon/InitialsIcon.jsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from 'react'
 import './InitialsIcon.css'
 
 const InitialsIcon = ({ visible = false }) => {


### PR DESCRIPTION
Add a fixed, fade-in initials icon (BC) to the top-left for branding and scroll-to-top navigation.