### PR TITLE
Improve spacing for technology icons

### DIFF
--- a/src/components/TechStackIcons/TechStackIcons.css
+++ b/src/components/TechStackIcons/TechStackIcons.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin: 12px 0;
+  margin: 12px 0 48px 0;
   opacity: 0;
   transform: translateY(10px);
   transition: opacity 0.6s ease, transform 0.6s ease;
@@ -88,6 +88,7 @@
 @media (max-width: 768px) {
   .tech-stack-icons {
     gap: 6px;
+    margin: 12px 0 44px 0;
   }
   
   .tech-icon {


### PR DESCRIPTION
Increase bottom margin of tech stack icons to prevent hover tooltips from overlapping with content below.

---

[Open in Web](https://cursor.com/agents?id=bc-45f01dee-d8ed-4b0d-a03d-9df70ec6b073) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-45f01dee-d8ed-4b0d-a03d-9df70ec6b073) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)