### PR TITLE
Add clickable icon to title hyperlink parameter

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ function App() {
     {
       id: 6,
       name: "Mashgin",
+      titleHyperlink: "https://www.mashgin.com/",
       techStack: ["python", "vue", "mysql", "redis"],
       descriptions: [
         "Building the future of AI-powered self-checkout kiosks."

--- a/src/components/ExperienceList/ExperienceList.css
+++ b/src/components/ExperienceList/ExperienceList.css
@@ -104,6 +104,32 @@
   text-shadow: 0 2px 4px var(--color-shadow-text);
 }
 
+.title-hyperlink {
+  color: inherit;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: all 0.3s ease;
+}
+
+.title-hyperlink:hover {
+  color: inherit;
+  text-decoration: none;
+}
+
+.external-link-icon {
+  font-size: 0.8em;
+  opacity: 0.7;
+  transition: all 0.3s ease;
+  font-weight: normal;
+}
+
+.title-hyperlink:hover .external-link-icon {
+  opacity: 1;
+  transform: translate(2px, -2px);
+}
+
 .experience-list-items {
   list-style: none;
   padding: 0;

--- a/src/components/ExperienceList/ExperienceList.jsx
+++ b/src/components/ExperienceList/ExperienceList.jsx
@@ -59,9 +59,10 @@ const ExperienceList = ({ items = [] }) => {
           {selectedItem && descriptionVisible && (
             <div key={selectedItem.id} className="experience-descriptions">
               <h3 className="experience-title">
-                {selectedItem.name === "Mashgin" ? (
-                  <a href="https://www.mashgin.com/" target="_blank" rel="noopener noreferrer">
+                {selectedItem.titleHyperlink ? (
+                  <a href={selectedItem.titleHyperlink} target="_blank" rel="noopener noreferrer" className="title-hyperlink">
                     {selectedItem.name}
+                    <span className="external-link-icon">↗</span>
                   </a>
                 ) : (
                   selectedItem.name


### PR DESCRIPTION
Add a configurable `titleHyperlink` parameter to `ExperienceList` to display an external link icon next to clickable titles, starting with Mashgin, without altering their color.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9c978d9-99a1-4999-ac69-4e88da5c1324">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f9c978d9-99a1-4999-ac69-4e88da5c1324">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

