### PR TITLE
Shorten company titles in listings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,7 +39,7 @@ function App() {
     },
     {
       id: 4,
-      name: "Glidewell Dental Labs",
+      name: "Glidewell",
       titleHyperlink: "https://www.glidewell.com/",
       techStack: ["csharp", "dotnet", "react", "mongodb", "nodejs", "typescript"],
       descriptions: [
@@ -57,7 +57,7 @@ function App() {
     },
     {
       id: 2,
-      name: "Amazon (AWS, Luna)",
+      name: "Amazon",
       titleHyperlink: "https://aws.amazon.com/",
       techStack: ["c", "python", "react", "typescript", "java", "linux"],
       descriptions: [


### PR DESCRIPTION
Simplify company titles 'Glidewell Dental Labs' to 'Glidewell' and 'Amazon (AWS, Luna)' to 'Amazon' as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2e33cf2-be2f-4afe-93be-43bc84c46f87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f2e33cf2-be2f-4afe-93be-43bc84c46f87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

