### PR TITLE
Update experience section titles for Amazon and Glidewell

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ function App() {
   const experienceData = [
     {
       id: 6,
+      title: "Mashgin",
       name: "Mashgin",
       titleHyperlink: "https://www.mashgin.com/",
       techStack: ["python", "vue", "mysql", "redis"],
@@ -29,6 +30,7 @@ function App() {
     },
     {
       id: 5,
+      title: "Geico",
       name: "Geico",
       titleHyperlink: "https://www.geico.com/",
       techStack: ["csharp", "dotnet", "azure", "kubernetes", "redis", "sqlserver"],
@@ -39,6 +41,7 @@ function App() {
     },
     {
       id: 4,
+      title: "Glidewell",
       name: "Glidewell Dental Labs",
       titleHyperlink: "https://www.glidewell.com/",
       techStack: ["csharp", "dotnet", "react", "mongodb", "nodejs", "typescript"],
@@ -49,6 +52,7 @@ function App() {
     },
     {
       id: 3,
+      title: "Happy Money",
       name: "Happy Money",
       techStack: ["java", "spring"],
       descriptions: [
@@ -57,6 +61,7 @@ function App() {
     },
     {
       id: 2,
+      title: "Amazon",
       name: "Amazon (AWS, Luna)",
       titleHyperlink: "https://aws.amazon.com/",
       techStack: ["c", "python", "react", "typescript", "java", "linux"],
@@ -69,6 +74,7 @@ function App() {
     },
     {
       id: 1,
+      title: "iHerb",
       name: "iHerb",
       titleHyperlink: "https://www.iherb.com/",
       techStack: ["csharp", "dotnet", "sqlserver"],

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,7 +39,7 @@ function App() {
     },
     {
       id: 4,
-      name: "Glidewell",
+      name: "Glidewell Dental Labs",
       titleHyperlink: "https://www.glidewell.com/",
       techStack: ["csharp", "dotnet", "react", "mongodb", "nodejs", "typescript"],
       descriptions: [
@@ -57,7 +57,7 @@ function App() {
     },
     {
       id: 2,
-      name: "Amazon",
+      name: "Amazon (AWS, Luna)",
       titleHyperlink: "https://aws.amazon.com/",
       techStack: ["c", "python", "react", "typescript", "java", "linux"],
       descriptions: [

--- a/src/components/ExperienceList/ExperienceList.jsx
+++ b/src/components/ExperienceList/ExperienceList.jsx
@@ -48,7 +48,7 @@ const ExperienceList = ({ items = [] }) => {
               style={{ animationDelay: `${index * 0.2}s` }}
             >
               <div className="experience-text">
-                {item.name}
+                {item.title}
               </div>
             </div>
           ))}


### PR DESCRIPTION
Update Amazon and Glidewell experience section titles to be more descriptive.

---
<a href="https://cursor.com/background-agent?bcId=bc-c220579c-4d51-4d95-b5a8-047e961294dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c220579c-4d51-4d95-b5a8-047e961294dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

