### PR TITLE
Fix scrolling glitch on bottom

### DIFF
--- a/src/components/InitialsIcon/InitialsIcon.css
+++ b/src/components/InitialsIcon/InitialsIcon.css
@@ -23,6 +23,10 @@
   backdrop-filter: blur(10px);
   box-shadow: 0 2px 20px rgba(0, 0, 0, 0.1);
   border: 1px solid rgba(255, 255, 255, 0.2);
+  /* Prevent touch events from interfering with scrolling */
+  touch-action: manipulation;
+  /* Ensure the element doesn't interfere with scroll gestures */
+  pointer-events: auto;
 }
 
 .initials-icon.fade-in {
@@ -36,8 +40,10 @@
   background: rgba(255, 255, 255, 1);
 }
 
-.initials-icon:active {
+.initials-icon:active,
+.initials-icon.pressed {
   transform: translateY(0) scale(0.95);
+  background: rgba(255, 255, 255, 0.8);
 }
 
 /* Responsive design for mobile devices */
@@ -52,6 +58,8 @@
     /* Semi-transparent on mobile to be less intrusive */
     background: rgba(255, 255, 255, 0.8);
     backdrop-filter: blur(8px);
+    /* Reduce touch sensitivity on mobile */
+    touch-action: manipulation;
   }
 }
 
@@ -66,5 +74,7 @@
     /* Even more subtle on small screens */
     background: rgba(255, 255, 255, 0.7);
     backdrop-filter: blur(6px);
+    /* Further reduce touch sensitivity on small screens */
+    touch-action: manipulation;
   }
 }

--- a/src/components/InitialsIcon/InitialsIcon.jsx
+++ b/src/components/InitialsIcon/InitialsIcon.jsx
@@ -1,17 +1,59 @@
 import './InitialsIcon.css'
+import { useState, useRef } from 'react'
 
 const InitialsIcon = ({ visible = false }) => {
+  const [isPressed, setIsPressed] = useState(false)
+  const touchStartY = useRef(0)
+  const touchStartTime = useRef(0)
+  const lastScrollTime = useRef(0)
+
   const handleClick = () => {
+    const now = Date.now()
+    // Prevent rapid successive scroll-to-top calls (debounce)
+    if (now - lastScrollTime.current < 1000) {
+      return
+    }
+    
+    lastScrollTime.current = now
+    // Only scroll to top on intentional click, not accidental touch during scrolling
     window.scrollTo({
       top: 0,
       behavior: 'smooth'
     })
   }
 
+  const handleTouchStart = (e) => {
+    touchStartY.current = e.touches[0].clientY
+    touchStartTime.current = Date.now()
+    setIsPressed(true)
+  }
+
+  const handleTouchEnd = (e) => {
+    const touchEndY = e.changedTouches[0].clientY
+    const touchDuration = Date.now() - touchStartTime.current
+    const touchDistance = Math.abs(touchEndY - touchStartY.current)
+    
+    // Only trigger click if it's a short, stationary touch (not a scroll gesture)
+    // Increased distance threshold to be more forgiving on mobile
+    if (touchDuration < 300 && touchDistance < 15) {
+      handleClick()
+    }
+    
+    setIsPressed(false)
+  }
+
+  const handleTouchMove = () => {
+    // Cancel the press state if user is scrolling
+    setIsPressed(false)
+  }
+
   return (
     <div 
-      className={`initials-icon ${visible ? 'fade-in' : ''}`}
+      className={`initials-icon ${visible ? 'fade-in' : ''} ${isPressed ? 'pressed' : ''}`}
       onClick={handleClick}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      onTouchMove={handleTouchMove}
     >
       BC
     </div>


### PR DESCRIPTION
Implement smart touch detection and CSS improvements for the `InitialsIcon` to prevent accidental scroll-to-top triggers on mobile.

The `InitialsIcon`'s click handler, which scrolls to the top, was being accidentally triggered by touch events during normal scrolling on mobile, causing the page to unexpectedly reset. This fix differentiates between intentional taps and scroll gestures.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac2f9875-8735-4ec1-bdd6-2008377333cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac2f9875-8735-4ec1-bdd6-2008377333cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

