### PR TITLE
Fix scroll jitter and scroll-to-top icon

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -78,7 +78,7 @@ body {
   min-height: 100dvh; /* Dynamic viewport height for mobile */
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- Anchor root element to top instead of centering to eliminate jitter when scrolling to long experience sections
- Ensure InitialsIcon always scrolls back to top after slight scroll by removing vertical centering side-effects

## Testing
- `npm test` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fd4566fc8327b439709177cae02d