### PR TITLE
Format experience titles into a grid

### DIFF
--- a/src/components/ExperienceList/ExperienceList.css
+++ b/src/components/ExperienceList/ExperienceList.css
@@ -26,13 +26,21 @@
 
 /* Top Experience Bar */
 .experience-icon-bar {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: center;
-  padding: 2rem;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: 1rem;
-  flex-wrap: wrap;
+  padding: 2rem;
   border-bottom: 1px solid var(--color-border-primary);
+  justify-items: center;
+}
+
+/* Center items when there are fewer than 3 per row */
+.experience-icon-bar.single-item {
+  grid-template-columns: 1fr;
+}
+
+.experience-icon-bar.two-items {
+  grid-template-columns: repeat(2, 1fr);
 }
 
 .experience-icon-item {
@@ -227,6 +235,15 @@
   .experience-icon-bar {
     padding: 1.5rem;
     gap: 0.75rem;
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .experience-icon-bar.single-item {
+    grid-template-columns: 1fr;
+  }
+
+  .experience-icon-bar.two-items {
+    grid-template-columns: repeat(2, 1fr);
   }
 
   .experience-icon-item {
@@ -283,6 +300,15 @@
   .experience-icon-bar {
     padding: 1rem;
     gap: 0.5rem;
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .experience-icon-bar.single-item {
+    grid-template-columns: 1fr;
+  }
+
+  .experience-icon-bar.two-items {
+    grid-template-columns: repeat(2, 1fr);
   }
 
   .experience-icon-item {

--- a/src/components/ExperienceList/ExperienceList.jsx
+++ b/src/components/ExperienceList/ExperienceList.jsx
@@ -39,7 +39,7 @@ const ExperienceList = ({ items = [] }) => {
     <div className="experience-list">
       <div className="experience-container">
         {/* Top Experience Bar */}
-        <div className="experience-icon-bar">
+        <div className={`experience-icon-bar ${items.length === 1 ? 'single-item' : items.length === 2 ? 'two-items' : ''}`}>
           {items.map((item, index) => (
             <div
               key={item.id}


### PR DESCRIPTION
Convert experience titles to a responsive 3-column CSS grid layout with dynamic centering for fewer items.

---
<a href="https://cursor.com/background-agent?bcId=bc-1123d68c-1184-43fb-9604-4d21b82027cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1123d68c-1184-43fb-9604-4d21b82027cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Converts the experience icon bar to a responsive 3-column CSS grid with dynamic centering when there are 1–2 items.
> 
> - **Frontend**:
>   - **`ExperienceList.css`**:
>     - Replace flex layout in `experience-icon-bar` with a 3-column CSS grid; add `justify-items: center`.
>     - Add modifier classes `single-item` and `two-items` to center layouts for <3 items.
>     - Mirror grid column behavior in mobile media queries.
>   - **`ExperienceList.jsx`**:
>     - Add conditional class on `experience-icon-bar` based on `items.length` to apply `single-item`/`two-items`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d695135cc39f090e1456d5937fb6ad8d2fe654ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->