### PR TITLE
Upgrade GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-        
+        uses: actions/checkout@v7
+
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '18'
           cache: 'npm'
@@ -43,11 +43,11 @@ jobs:
         
       - name: Setup Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: actions/configure-pages@v4
-        
+        uses: actions/configure-pages@v6
+
       - name: Upload artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './dist'
 
@@ -62,4 +62,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- GitHub Actions runners are deprecating Node 20; several actions we use were being force-run on Node 24 with a deprecation warning.
- Bumped `actions/checkout` v4→v7, `actions/setup-node` v4→v7, `actions/configure-pages` v4→v6, `actions/upload-pages-artifact` v3→v5, and `actions/deploy-pages` v4→v5 — all latest majors that natively target Node 24.
- Added `.github/dependabot.yml` for the `github-actions` ecosystem (weekly) so future action-version drift gets flagged via PR before it turns into a runtime deprecation warning.

## Test plan
- [x] `npm ci` succeeds locally
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] CI workflow run on this PR completes successfully (build job), no deprecation warning in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HAQ7YTM1LQEMWujpm5pPkv